### PR TITLE
Allow registering types of functions

### DIFF
--- a/src/SystemMetadata.zig
+++ b/src/SystemMetadata.zig
@@ -8,6 +8,7 @@ pub const Arg = enum {
     value,
 };
 
+function_type: type,
 fn_info: FnInfo,
 args: []const Arg,
 
@@ -68,6 +69,7 @@ pub fn init(comptime function_type: type, comptime fn_info: FnInfo) SystemMetada
         }
     }
     return SystemMetadata{
+        .function_type = function_type,
         .fn_info = fn_info,
         .args = args[0..],
     };


### PR DESCRIPTION
Extend CreateWorld to support struct types containing multiple systems

This resolves issue #17