### PR TITLE
build.zig.zon: Update ztracy

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .ztracy = .{
-            .url = "https://github.com/zig-gamedev/ztracy/archive/b14c70625294de7c98fc08f7b6bd327dca01c79c.tar.gz",
-            .hash = "1220db44aa021874e7d813a816e79c1a60ac8b67ea7e31846c242f0736277353196d",
+            .url = "git+https://github.com/zig-gamedev/ztracy?ref=main#be3d003f29d59d72e68e493ab531374ab474a795",
+            .hash = "ztracy-0.14.0-dev-zHJSq1oQFwCAq2LhbqsBUmZAipMzsD8UfKL5Etc_OJMb",
         },
     },
     .paths = .{


### PR DESCRIPTION
This includes an updated version of the allocator wrapper compatible with zig 0.14.0