### PR TITLE
Fix waiting for single threaded event

### DIFF
--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -202,6 +202,7 @@ pub fn CreateScheduler(comptime events: anytype) type {
                 const dispatch_exec_func = DispatchJob.exec;
                 if (builtin.single_threaded or self.thread_pool.threads.len == 0 or triggered_event._run_on_main_thread) {
                     @call(.auto, dispatch_exec_func, .{system_job});
+                    self.event_systems_running[event_index].store(0, .monotonic);
                     return;
                 }
 
@@ -824,6 +825,7 @@ test "Thread count 0 works" {
         )}).init(.{
             .pool_allocator = std.testing.allocator,
             .query_submit_allocator = std.testing.allocator,
+            .thread_count = 0,
         });
         defer scheduler.deinit();
 


### PR DESCRIPTION
The rework of the dependency chain seems to have broken waiting for single threaded events. As there is no closure, the number of running systems was never decreased, and waiting for an event spun indefinitely.